### PR TITLE
attempt to fix issue #54

### DIFF
--- a/tools/clitkDicom2Image.cxx
+++ b/tools/clitkDicom2Image.cxx
@@ -32,6 +32,9 @@
 #endif
 
 #include <set>
+#include <cstring>
+#include <cstdlib>
+#include <libgen.h>
 
 //====================================================================
 int main(int argc, char * argv[])
@@ -226,8 +229,10 @@ int main(int argc, char * argv[])
       outfile = args_info.output_arg;
     else {
       std::ostringstream name;
-      name << *sn << "_" << args_info.output_arg;
+      char* output_arg = strdup(args_info.output_arg); // basename/dirname may edit their argument
+      name << dirname(output_arg) << "/" << *sn << "_" << basename(output_arg);
       outfile = name.str();
+      free(output_arg);
     }
     //Check on transform
     bool bId = true;


### PR DESCRIPTION
this is a relatively minimal attempt at fixing issue #54 

Possible improvements:

- I could not find native C++ library functions exist to get dirname and/or basename, but if they do exist then those should be used instead of the C-functions that I am using now.
- If user specifies a directory for output then we could check that it indeed exists and is writable, and if it does then terminate with a clearer error message than the ITK writer does.
- the command line option documentation could be updated to describe what will happen in case of multiple output images.