### PR TITLE
avoid segfault when adding ROI to image w/o trafo

### DIFF
--- a/vv/vvBinaryImageOverlayActor.cxx
+++ b/vv/vvBinaryImageOverlayActor.cxx
@@ -122,7 +122,9 @@ void vvBinaryImageOverlayActor::Initialize(bool IsVisible)
 
     vtkSmartPointer<vtkTransform> mConcatenatedFusionTransform = vtkSmartPointer<vtkTransform>::New();
     mConcatenatedFusionTransform->Identity();
-    mConcatenatedFusionTransform->Concatenate(mImage->GetTransform()[0]);
+    if (!mImage->GetTransform().empty()){
+      mConcatenatedFusionTransform->Concatenate(mImage->GetTransform()[0]);
+    }
     mConcatenatedFusionTransform->Concatenate(mSlicer->GetSlicingTransform());
     mFusionReslice->SetResliceAxes(mConcatenatedFusionTransform->GetMatrix());
     if (mImage->IsTimeSequence()) {


### PR DESCRIPTION
we got segfaults with VV when doing the following
1. start VV
2. select CT image set (DICOM)
3. open ROI from DICOM

The segfault happened right after we had selected the names of the ROIs to be selected from the RS.* file.

After compiling VV as a "Debug" build and running the above steps in gdb, the
backtrace showed that the crash was caused in line 125 of
vvBinaryImageOverlayActor.cxx.  Apparently our CT image was represented without
any transformation at that point in the code, while the code assumed that there
would always be a transformation.

If it is DICOM-wise or VTK-wise legal for an image to have an empty vector of
transformations, then I think that my fix is sufficient.

If you think that it is anomalous that this vector was empty in our case, then
I think more work is needed. For instance, if this situation could really only
happen if the input data is somehow corrupt, then the user should get an
informative error message about that, and maybe VV just terminates after that
in a more controlled way. Or maybe VV should just provide identity trafo to
images that have an empty trafo vector. Or, less likely, maybe the image did
have a trafo but VV somehow manages to lose it? In all these cases this PR is
insufficient. I can't tell myself, because I am not an image expert. :-)