### PR TITLE
Debug vv with VTK8.2

### DIFF
--- a/vv/vv.cxx
+++ b/vv/vv.cxx
@@ -42,6 +42,9 @@
 #include "vvReadState.h"
 #include "vvToolsList.h"
 #include "vvConfiguration.h"
+#if (VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION >= 2) || VTK_MAJOR_VERSION >= 9
+#include <QVTKOpenGLWidget.h>
+#endif
 
 #include <vtkFileOutputWindow.h>
 #include <vtkSmartPointer.h>
@@ -115,6 +118,9 @@ int main( int argc, char** argv )
 {
 #endif
 
+#if (VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION >= 2) || VTK_MAJOR_VERSION >= 9
+  QSurfaceFormat::setDefaultFormat(QVTKOpenGLWidget::defaultFormat());
+#endif
   CLITK_INIT;
 
   QApplication app( argc, argv );

--- a/vv/vvMainWindow.cxx
+++ b/vv/vvMainWindow.cxx
@@ -372,11 +372,13 @@ vvMainWindow::vvMainWindow():vvMainWindowBase()
   SOViewWidget->hide();
   SEViewWidget->hide();
 
+#if (VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION < 2) || VTK_MAJOR_VERSION < 8
 #ifdef Q_OS_OSX
   disableGLHiDPI(NOViewWidget->winId());
   disableGLHiDPI(NEViewWidget->winId());
   disableGLHiDPI(SOViewWidget->winId());
   disableGLHiDPI(SEViewWidget->winId());
+#endif
 #endif
 
   //Recently opened files


### PR DESCRIPTION
With VTK 8.2, we need to initialize the OpenGL backend
Need to remove disableGLHiDPI. It creates a conflict with the previous initialization and display wrong things