### PR TITLE
Active the menu automatically on MacOs

### DIFF
--- a/vv/CMakeLists.txt
+++ b/vv/CMakeLists.txt
@@ -390,6 +390,8 @@ target_link_libraries(vvLib ${vvExternalLibs})
 
 if(WIN32)
   add_executable(vv WIN32 vv.cxx vvIcon.rc)
+elseif(APPLE)
+  add_executable(vv MACOSX_BUNDLE vv.cxx)
 else(WIN32)
   add_executable(vv vv.cxx)
 endif(WIN32)


### PR DESCRIPTION
Before, we need to unfocus/focus vv to activate the menu on MacOS. Now it's done automatically.
With Bundle, MacOs understand that vv is an App.
The negative point is that the executable of vv now is in that folder:
bin/vv.app/Contents/MacOS/