### PR TITLE
add an option to clitkDicom2Image to force double pixel type

### DIFF
--- a/common/vvImageReader.cxx
+++ b/common/vvImageReader.cxx
@@ -81,6 +81,27 @@ void vvImageReader::Update(LoadedImageType type)
 
 
 //------------------------------------------------------------------------------
+void vvImageReader::Update(std::string inputPixelType, LoadedImageType type)
+{
+  itk::ImageIOBase::Pointer reader = itk::ImageIOFactory::CreateImageIO(mInputFilenames[0].c_str(), itk::ImageIOFactory::ReadMode);
+  if (!reader) {
+    mLastError="Unable to read file.";
+  } else {
+    reader->SetFileName(mInputFilenames[0]);
+    gdcm::ImageHelper::SetForcePixelSpacing(true);
+    reader->ReadImageInformation();
+    if (mInputFilenames.size() > 1)
+      Update(reader->GetNumberOfDimensions()+1,inputPixelType, type);
+    else if (reader->GetNumberOfComponents() > 1 && type != VECTORFIELD && type != VECTORFIELDWITHTIME)
+      Update(reader->GetNumberOfDimensions()+1,inputPixelType,VECTORPIXELIMAGE);
+    else
+      Update(reader->GetNumberOfDimensions(),inputPixelType, type);
+  }
+}
+//------------------------------------------------------------------------------
+
+
+//------------------------------------------------------------------------------
 void vvImageReader::Update(int dim,std::string inputPixelType, LoadedImageType type)
 {
   //CALL_FOR_ALL_DIMS(dim,UpdateWithDim,inputPixelType);

--- a/common/vvImageReader.h
+++ b/common/vvImageReader.h
@@ -65,6 +65,7 @@ public:
   // Main function
   void Update();
   void Update(LoadedImageType type);
+  void Update(std::string inputPixelType, LoadedImageType type);
   void Update(int dim, std::string InputPixelType, LoadedImageType type);
 
 protected:

--- a/tools/clitkDicom2Image.cxx
+++ b/tools/clitkDicom2Image.cxx
@@ -256,7 +256,11 @@ int main(int argc, char * argv[])
     vvImageReader::Pointer reader = vvImageReader::New();
     reader->SetInputFilenames(sorted_files);
     reader->SetPatientCoordinateSystem(args_info.patientSystem_flag);
-    reader->Update(vvImageReader::DICOM);
+    if (args_info.setDouble_flag) {
+      reader->Update("double", vvImageReader::DICOM);
+    } else {
+      reader->Update(vvImageReader::DICOM);
+    }
     if (reader->GetLastError().size() != 0) {
       std::cerr << reader->GetLastError() << std::endl;
       return 1;

--- a/tools/clitkDicom2Image.ggo
+++ b/tools/clitkDicom2Image.ggo
@@ -11,3 +11,4 @@ option "focal_origin"   - "Output files with FOCAL-like origin, instead of the o
 option "patientSystem"  p "Open the image with patient coordinate system" flag off
 option "instanceNumber" n "Sort the images regarding instance number in dicom tag" flag off
 option "reverse"        r "Reverse the slice order" flag off
+option "setDouble"      d "Read input (and save output) as double pixel type" flag off


### PR DESCRIPTION
I added an option to the tool clitkDicom2Image that forces the input pixel values to be read as double.